### PR TITLE
Add missing parameter to grid-generate-classes()

### DIFF
--- a/core/_grid-generate-classes.scss
+++ b/core/_grid-generate-classes.scss
@@ -12,7 +12,7 @@
 ///   @include grid-generate-classes($example);
 ///
 
-@mixin grid-generate-classes() {
+@mixin grid-generate-classes($grid) {
   @if map-has-key($grid, class) != true {
     @error "⚠️  Your grid map must contain a defined `class:` property."
   }


### PR DESCRIPTION
This pull requests adds the missing parameter to the grid-generate-classes() definition. Without it, there's really no way to generate classes for custom grids.